### PR TITLE
Backport fix to PriorityQueue.offer() for first element

### DIFF
--- a/expectations/knownfailures.txt
+++ b/expectations/knownfailures.txt
@@ -1809,7 +1809,6 @@
     "test.java.util.concurrent.tck.ForkJoinPoolTest#testSubmitFailedPrivilegedExceptionAction",
     "test.java.util.concurrent.tck.ForkJoinPoolTest#testSubmitPrivilegedAction",
     "test.java.util.concurrent.tck.ForkJoinPoolTest#testSubmitPrivilegedExceptionAction",
-    "test.java.util.concurrent.tck.PriorityQueueTest#testOfferNonComparable",
     "test.java.util.concurrent.tck.StampedLockTest#testDeeplyNestedReadLocks",
     "test.java.util.concurrent.tck.StampedLockTest#testReadLock_lockUnlock",
     "test.java.util.concurrent.tck.StampedLockTest#testTryConvertToOptimisticRead",

--- a/harmony-tests/src/test/java/org/apache/harmony/tests/java/util/PriorityQueueTest.java
+++ b/harmony-tests/src/test/java/org/apache/harmony/tests/java/util/PriorityQueueTest.java
@@ -650,7 +650,7 @@ public class PriorityQueueTest extends TestCase {
         integerQueue1.offer(1);
         assertFalse(integerQueue1.remove(new Float(1.3F)));
 
-        PriorityQueue<Object> queue = new PriorityQueue<Object>();
+        PriorityQueue<Object> queue = new PriorityQueue<Object>(comparator);
         Object o = new Object();
         queue.offer(o);
         assertTrue(queue.remove(o));

--- a/ojluni/src/main/java/java/util/PriorityQueue.java
+++ b/ojluni/src/main/java/java/util/PriorityQueue.java
@@ -337,11 +337,15 @@ public class PriorityQueue<E> extends AbstractQueue<E>
         int i = size;
         if (i >= queue.length)
             grow(i + 1);
+        // Android-changed: Backport fix which checks first element is Comparable
+        // if comparator is null
+        // size = i + 1;
+        // if (i == 0)
+        //     queue[0] = e;
+        // else
+        //     siftUp(i, e);
+        siftUp(i, e);
         size = i + 1;
-        if (i == 0)
-            queue[0] = e;
-        else
-            siftUp(i, e);
         return true;
     }
 


### PR DESCRIPTION
The fix is taken from
https://github.com/openjdk/jdk/commit/559140e18edc3da944633e8e87719608b5dc4688

Fixes: 224733332
Test: atest PriorityQueueTest
Change-Id: I06f0b6c53dd51046b52a9e3783407aed4ebbcf8b